### PR TITLE
Add latest py-pint which supports latest numpy

### DIFF
--- a/spack_repo/scientificcomputing/packages/py_pint/package.py
+++ b/spack_repo/scientificcomputing/packages/py_pint/package.py
@@ -1,0 +1,74 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.python import PythonPackage
+
+from spack.package import *
+
+
+class PyPint(PythonPackage):
+    """Pint is a Python package to define, operate and manipulate physical
+    quantities: the product of a numerical value and a unit of measurement.
+    It allows arithmetic operations between them and conversions from and
+    to different units."""
+
+    homepage = "https://github.com/hgrecco/pint"
+    pypi = "pint/pint-0.11.tar.gz"
+
+    license("BSD-3-Clause")
+
+    # 'pint' requires 'xarray', creating a circular dependency. Don't bother attempting
+    # any import tests for this package.
+    import_modules = []  # type: List[str]
+    version("0.25.3", sha256="f8f5df6cf65314d74da1ade1bf96f8e3e4d0c41b51577ac53c49e7d44ca5acee")
+    version("0.24.4", sha256="35275439b574837a6cd3020a5a4a73645eb125ce4152a73a2f126bf164b91b80")
+    version("0.22", sha256="2d139f6abbcf3016cad7d3cec05707fe908ac4f99cf59aedfd6ee667b7a64433")
+    version("0.21.1", sha256="5d5b6b518d0c5a7ab03a776175db500f1ed1523ee75fb7fafe38af8149431c8d")
+    version("0.20.1", sha256="387cf04078dc7dfe4a708033baad54ab61d82ab06c4ee3d4922b1e45d5626067")
+    version("0.19.2", sha256="e1d4989ff510b378dad64f91711e7bdabe5ca78d75b06a18569ac454678c4baf")
+    version("0.18", sha256="8c4bce884c269051feb7abc69dbfd18403c0c764abc83da132e8a7222f8ba801")
+    version("0.17", sha256="f4d0caa713239e6847a7c6eefe2427358566451fe56497d533f21fb590a3f313")
+    version("0.11", sha256="308f1070500e102f83b6adfca6db53debfce2ffc5d3cbe3f6c367da359b5cf4d")
+    version("0.10.1", sha256="d739c364b8326fe3d70773d5720fa8b005ea6158695cad042677a588480c86e6")
+    version("0.10", sha256="38a4d6e242b8bab693cd83a5f5ade3d816463b498658e7ab14ce64c4d458c88b")
+    version("0.9", sha256="32d8a9a9d63f4f81194c0014b3b742679dce81a26d45127d9810a68a561fe4e2")
+    version("0.8.1", sha256="afcf31443a478c32bbac4b00337ee9026a13d0e2ac83d30c79151462513bb0d4")
+
+    variant("numpy", default=False, description="Optional numpy support")
+    variant("xarray", default=False, description="Optional xarray support")
+    variant("dask", default=False, description="Optional dask support")
+
+    depends_on("python@3.9:", when="@0.22:", type=("build", "run"))
+    depends_on("python@3.8:", when="@0.19:0.21", type=("build", "run"))
+
+    depends_on("py-hatchling", when="@0.25:", type="build")
+    depends_on("py-setuptools@61:", when="@0.21:", type="build")
+    depends_on("py-setuptools@41:", when="@0.16:0.20", type="build")
+    depends_on("py-setuptools@41:", when="@0.11:0.15", type=("build", "run"))
+    depends_on("py-setuptools", when="@:0.10", type=("build", "run"))
+    depends_on("py-setuptools-scm@3.4.3:+toml", when="@0.11:", type="build")
+    depends_on("py-setuptools-scm", when="@0.10", type="build")
+    depends_on("py-packaging", when="@0.13:18", type=("build", "run"))
+    depends_on("py-importlib-metadata", when="@0.13:18 ^python@:3.7", type=("build", "run"))
+
+    depends_on("py-typing-extensions", when="@0.22:", type=("build", "run"))
+
+    # https://github.com/hgrecco/pint/blob/0.24.4/requirements.txt
+    depends_on("py-platformdirs@2.1.0:", when="@0.24:")
+    depends_on("py-typing-extensions@4.0.0:", when="@0.24:", type=("build", "run"))
+    depends_on("py-flexcache@0.3:", when="@0.24:")
+    depends_on("py-flexparser@0.4:", when="@0.24:")
+
+    # variant depends
+    depends_on("py-numpy@1", when="@:0.22 +numpy")
+    depends_on("py-numpy@1.23:", when="@0.24: +numpy")  # numpy 2 added in 0.24
+    depends_on("py-xarray", when="+xarray")
+    depends_on("py-dask", when="+dask")
+
+    def url_for_version(self, version):
+        if version > Version("0.22"):
+            return super().url_for_version(version)
+
+        url = "https://files.pythonhosted.org/packages/source/p/pint/Pint-{0}.tar.gz"
+        return url.format(version.dotted)


### PR DESCRIPTION
The current version of pint on spack error on import due to this error: https://github.com/numpy/numpy/issues/26781, see e.g https://github.com/scientificcomputing/spack_repos/actions/runs/26000576434/job/76422965288

This PR add the latest version of pint